### PR TITLE
Fetch image as arraybuffer

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -484,6 +484,7 @@ export const createDeviceEndpoints = (
             scale,
           },
         },
+        parseAs: 'arrayBuffer'
       }
     );
 


### PR DESCRIPTION
Or else, `.takeScreenshot` throws.

`api.GET` converts automatically to JSON, resulting in a SyntaxError because it tried to interpret an image binary as JSON.